### PR TITLE
prepend leading slash to file arguments if not already present

### DIFF
--- a/lib/git_sme/analysis_presenter.rb
+++ b/lib/git_sme/analysis_presenter.rb
@@ -9,6 +9,7 @@ module GitSme
       @users = users
       @files = files
       @files = ['/'] unless @users.any? || @files.any?
+      @files.map! { |f| f.start_with?("/") ? "/#{f}" : f }
 
       @valid = @commit_analyzer.valid?
       @error_message = @commit_analyzer.error_message


### PR DESCRIPTION
This patch makes it possible to invoke without prepending file arguments
with a leading slash. Example:

    git-sme . --file path/to/file